### PR TITLE
Use vectors for managing canvases/pads, fix minor discrepancies

### DIFF
--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -56,8 +56,8 @@ int JetDraw::MakeHtml(const std::string &what) {
   QADrawClient *cl = QADrawClient::instance();
 
   // loop over triggers to draw
-  for (std::size_t iTrigToDraw = 0; iTrigToDraw < m_vecTrigToDraw.size(); ++iTrigToDraw) {
-
+  for (std::size_t iTrigToDraw = 0; iTrigToDraw < m_vecTrigToDraw.size(); ++iTrigToDraw)
+  {
     // grab index & name of trigger being drawn
     const uint32_t    idTrig   = m_vecTrigToDraw[iTrigToDraw];
     const std::string nameTrig = m_mapTrigToName[idTrig];
@@ -67,8 +67,8 @@ int JetDraw::MakeHtml(const std::string &what) {
     cl->CanvasToPng(m_vecRhoCanvas[iTrigToDraw], pngRho);
 
     // loop over jet resolutions to draw
-    for (std::size_t iResToDraw = 0; iResToDraw < m_vecResToDraw.size(); ++iResToDraw) {
-
+    for (std::size_t iResToDraw = 0; iResToDraw < m_vecResToDraw.size(); ++iResToDraw)
+    {
       // grab index & name of resolution being drawn
       const uint32_t    idRes   = m_vecResToDraw[iResToDraw];
       const std::string nameRes = m_mapResToName[idRes];
@@ -86,7 +86,6 @@ int JetDraw::MakeHtml(const std::string &what) {
       // draw seed plots 
       const std::string pngSeed = cl->htmlRegisterPage(*this, dirRes, fileRes + "_seed", "png");
       cl->CanvasToPng(m_vecSeedCanvas[iTrigToDraw][iResToDraw], pngSeed);
-
     }
   }
   return iret;  // Return after processing all triggers and resolutions
@@ -94,36 +93,61 @@ int JetDraw::MakeHtml(const std::string &what) {
 
 int JetDraw::Draw(const std::string &what)
 {
-
-   // 1st make sure there's enough space for each trigger
-   m_vecRhoCanvas.resize( m_vecTrigToDraw.size() );
-   m_vecCstCanvas.resize( m_vecTrigToDraw.size() );
-   m_vecKineCanvas.resize( m_vecTrigToDraw.size() );
-   m_vecSeedCanvas.resize( m_vecTrigToDraw.size() );
-
-   // now loop over triggers
+   // loop over triggers
    int iret = 0;
-   int iTrig = 0;
-   for (uint32_t trigToDraw : m_vecTrigToDraw) { // loop over triggers
-   
-     // reserve space for each resolution to draw
-     /* TODO may or may not need */
-     ++iTrig;
-     
-     if  (what == "ALL" || what == "RHO") {
+   int idraw = 0;
+   for (uint32_t trigToDraw : m_vecTrigToDraw)
+   {
+
+     // add new rows for reso.-dependent canvases
+     m_vecCstCanvas.push_back( {} );
+     m_vecKineCanvas.push_back( {} );
+     m_vecSeedCanvas.push_back( {} );
+
+     // likewise for the run pad vectors
+     m_vecCstRun.push_back( {} );
+     m_vecKineRun.push_back( {} );
+     m_vecSeedRun.push_back( {} );
+
+     // and same for the pad vectors (incl. the rho pads)
+     m_vecRhoPad.push_back( {} );
+     m_vecCstPad.push_back( {} );
+     m_vecKinePad.push_back( {} );
+     m_vecSeedPad.push_back( {} );
+
+     // draw rho plots
+     if  (what == "ALL" || what == "RHO")
+     {
        iret += DrawRho(trigToDraw);
        ++idraw;
      }
-     for (uint32_t resToDraw : m_vecResToDraw) {
-       if (what == "ALL" || what == "CONTSTITUENTS") {
+
+     // now loop over resolutions to draw
+     for (uint32_t resToDraw : m_vecResToDraw)
+     {
+
+       // add new column for reso.-depdent pad vectors
+       m_vecCstPad.back().push_back( {} );
+       m_vecKinePad.back().push_back( {} );
+       m_vecSeedPad.back().push_back( {} );
+
+       // draw constituent plots
+       if (what == "ALL" || what == "CONTSTITUENTS")
+       {
 	 iret += DrawConstituents(trigToDraw, static_cast<JetRes>(resToDraw));
 	 ++idraw;
        }
-       if (what == "ALL" || what == "KINEMATICCHECK") {                                                                                                                                        
+
+       // draw kinematic plots
+       if (what == "ALL" || what == "KINEMATICCHECK")
+       {
          iret += DrawJetKinematics(trigToDraw, static_cast<JetRes>(resToDraw));
          ++idraw;
        }
-       if (what == "ALL" || what == "SEEDCOUNT") {                                                                                                                                        
+
+       // draw seed plots
+       if (what == "ALL" || what == "SEEDCOUNT")
+       {
          iret += DrawJetSeed(trigToDraw, static_cast<JetRes>(resToDraw));
          ++idraw;
        }
@@ -131,7 +155,7 @@ int JetDraw::Draw(const std::string &what)
    }
 
    /* SetsPhenixStyle(); */
-/* REMOVE
+/* TODO REMOVE
    gStyle->SetTitleSize(gStyle->GetTitleSize("X")*2.0, "X");
    gStyle->SetTitleSize(gStyle->GetTitleSize("Y")*2.0, "Y");
    gStyle->SetPadLeftMargin(0.15);
@@ -152,66 +176,58 @@ int JetDraw::Draw(const std::string &what)
        iret = -1;
      }
      return iret;
- }
+}
  
-int JetDraw::MakeCanvas(const std::string &name, int num)
+int JetDraw::MakeCanvas(const std::string &name, const int nHist, TCanvas* canvas, TPad* run, VPad1D& pads)
 {
+  // instantiate draw client & grab display size
   QADrawClient *cl = QADrawClient::instance();
   int xsize = cl->GetDisplaySizeX();
   int ysize = cl->GetDisplaySizeY();
-  // xpos (-1) negative: do not draw menu bar
-  TC[num] = new TCanvas(name.c_str(), (boost::format("Jet Plots %d") % num).str().c_str(), -1, 0, (int) (xsize / 1.2), (int) (ysize / 1.2));
-  TC[num]->UseCurrentStyle();
+
+  // emit warning if canvas is already initialized
+  if (canvas)
+  {
+    std::cerr << "Warning: overwriting canvas '" << name << "'." << std::endl;
+  }
+
+  // create canvas
+  // n.b. xpos (-1) negative means do not draw menu bar
+  canvas = new TCanvas(name.data(), "", -1, 0, (int) (xsize / 1.2), (int) (ysize / 1.2));
+  canvas->UseCurrentStyle();
   gSystem->ProcessEvents();
 
-  if (num==1)
+  // divide canvas into appropriate no. of pads
+  const int   nRow = std::min(nHist, 2);
+  const int   nCol = (nHist / 2) + (nHist % 2);
+  const float bRow = 0.01;
+  const float bCol = 0.01;
+  if (nHist > 1)
   {
-    Pad[num][0] = new TPad((boost::format("mypad%d0") % num).str().c_str(), "put", 0.05, 0.25, 0.45, 0.75, 0);
-    Pad[num][1] = new TPad((boost::format("mypad%d1") % num).str().c_str(), "a", 0.5, 0.25, 0.95, 0.75, 0);
-
-    Pad[num][0]->Draw();
-    Pad[num][1]->Draw();
-  }
-  else if (num==7)
-  {
-    Pad[num][0] = new TPad((boost::format("mypad%d0") % num).str().c_str(), "", 0.05, 0.05, 0.95, 0.95, 0);
-    Pad[num][0]->Draw();
-  }
-  else if (num==5)
-  {
-    TC[num]->Divide(3, 2, 0.025, 0.025);
-    Pad[num][0] = (TPad*)TC[num]->GetPad(1);
-    Pad[num][1] = (TPad*)TC[num]->GetPad(2);
-    Pad[num][2] = (TPad*)TC[num]->GetPad(3);
-    Pad[num][3] = (TPad*)TC[num]->GetPad(4);
-    Pad[num][4] = (TPad*)TC[num]->GetPad(5);
-    Pad[num][5] = (TPad*)TC[num]->GetPad(6);
-
-    Pad[num][0]->Draw();
-    Pad[num][1]->Draw();
-    Pad[num][2]->Draw();
-    Pad[num][3]->Draw();
-    Pad[num][4]->Draw();
-    Pad[num][5]->Draw();
-  }
-  else
-  {
-    Pad[num][0] = new TPad((boost::format("mypad%d0") % num).str().c_str(), "put", 0.05, 0.52, 0.45, 0.97, 0);
-    Pad[num][1] = new TPad((boost::format("mypad%d1") % num).str().c_str(), "a", 0.5, 0.52, 0.95, 0.97, 0);
-    Pad[num][2] = new TPad((boost::format("mypad%d2") % num).str().c_str(), "name", 0.05, 0.02, 0.45, 0.47, 0);
-    Pad[num][3] = new TPad((boost::format("mypad%d3") % num).str().c_str(), "here", 0.5, 0.02, 0.95, 0.47, 0);
-
-    Pad[num][0]->Draw();
-    Pad[num][1]->Draw();
-    Pad[num][2]->Draw();
-    Pad[num][3]->Draw();
+    canvas->Divide(nRow, nCol, bRow, bCol);
   }
 
-  // this one is used to plot the run number on the canvas
-  transparent[num] = new TPad((boost::format("transparent%d") % num).str().c_str(), "this does not show", 0, 0, 1, 1);
-  transparent[num]->SetFillStyle(4000);
-  transparent[num]->Draw();
+  // add pad pointers to vector & draw
+  const std::size_t nPads = nRow * nCol;
+  for (std::size_t iPad = 0; iPad < nPads; ++iPad)
+  {
+    pads.push_back( (TPad*) canvas->GetPad(iPad) );
+    pads.back()->Draw();
+  }
 
+  // emit warning if pad for run already exists
+  if (run)
+  {
+    std::cerr << "Warning: overwriting run pad for canvas '" << name << "'." << std::endl;
+  }
+
+  // create pad for run number
+  const std::string runPadName = name + "_run";
+  run = new TPad(runPadName.data(), "this does not show", 0, 0, 1, 1);
+  run->SetFillStyle(4000);
+  run->Draw();
+
+  // return w/o error
   return 0;
 }
 
@@ -236,7 +252,9 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
     break;
   }
 
+  // grab relevant histograms from draw client
   QADrawClient *cl = QADrawClient::instance();
+
   TH1D *constituents_ncsts_cemc = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_cemc")));
   TH1D *constituents_ncsts_ihcal = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_ihcal")));
   TH1D *constituents_ncsts_ohcal = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_ohcal")));
@@ -247,266 +265,316 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
   TH1D *constituents_efracjet_ohcal = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjet_ohcal")));
   TH2D *constituents_efracjetvscalolayer = dynamic_cast<TH2D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjetcscalolayer")));
 
-  //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
-  //m_vecCanvas[trigToDraw].push_back(canvas);
- 
- // canvas 1                                                                                                                 
-  if (!gROOT->FindObject("jet1"))                 
-    {                                                                                    
-      MakeCanvas("jet1", 0);
-    }                                                                                                                                          
-    // TC[0]->Clear("D"); //                                                                      
-    Pad[0][0]->cd();                                                                                             
-    if (constituents_ncsts_cemc)                                                                                                                  
-      {                                                                                                                                           
-	constituents_ncsts_cemc->SetTitle("Jet N Constituents in CEMC");                                                                            
-	constituents_ncsts_cemc->SetXTitle("N Constituents");                                                                        
-	constituents_ncsts_cemc->SetYTitle("Counts");                    
-	constituents_ncsts_cemc->GetXaxis()->SetNdivisions(505);                                                                                 
-	constituents_ncsts_cemc->GetXaxis()->SetRangeUser(-1, 15);                                                   
-	constituents_ncsts_cemc->DrawCopy("HIST"); //1D histogram                                                                                         
-	gPad->UseCurrentStyle();                                                                                             
-	gPad->SetLogy();                                                   
-	//gPad->SetLogz() //No z axis   
-	gPad->SetRightMargin(0.15);                                                                                         
-      }                                                                             
-    else                                                                                                                     
-      {                                                                                                                                    
-	// histogram is missing                                                                                                             
-	return -1;                                                                               
-      }                
-    Pad[0][1]->cd();                                                                                                                
-    if (constituents_ncsts_ihcal)                                                                                                          
-      {                                                                                                                                 
-	constituents_ncsts_ihcal->SetTitle("Jet N Constituents in IHCal");                                                       
-	constituents_ncsts_ihcal->SetXTitle("N Constituents");                                                                           
-	constituents_ncsts_ihcal->SetYTitle("Counts");                                   
-	constituents_ncsts_ihcal->GetXaxis()->SetNdivisions(505);                                                         
-	constituents_ncsts_ihcal->DrawCopy("COLZ"); //I think it might be HIST because it's 1D                        
-	gPad->UseCurrentStyle();                                                                                                       
-	gPad->SetRightMargin(0.15);                                                            
-      }
-                                                                                                                   
-    Pad[0][2]->cd();                                                                                                                     
-    if (constituents_ncsts_ohcal)                                                                                                            
-      {                                                                                                                                             
-	constituents_ncsts_ohcal->SetTitle("Jet N Constituents in OHCal");                                     
-	constituents_ncsts_ohcal->SetXTitle("N Constituents");                                                                                               
-	constituents_ncsts_ohcal->SetYTitle("Counts");                                                                                               
-	constituents_ncsts_ohcal->GetXaxis()->SetNdivisions(505);                                                                  
-	constituents_ncsts_ohcal->DrawCopy("COLZ"); //2D Histogram                             
-	gPad->UseCurrentStyle();                                                                                                              
-	gPad->SetRightMargin(0.15);                                                                                         
-      }                                                                                                                                      
-    Pad[0][3]->cd();                                                                                                                  
-    if (constituents_ncsts_total)                                                                                                  
-      {                                                                                                          
-	constituents_ncsts_total->SetTitle("Jet N Constituents");                                                                          
-	constituents_ncsts_total->SetXTitle("N Constituents");
-	constituents_ncsts_total->GetXaxis()->SetNdivisions(505); //                                                                            
-	constituents_ncsts_total->SetYTitle("Counts");                                                                      
-	constituents_ncsts_total->DrawCopy("COLZ"); //No clue, this is a TProfile                                                           
-	gPad->UseCurrentStyle();                                                                            
-      }  
-    // canvas 2                                                                                                                                  
-    if (!gROOT->FindObject("jet2"))                                                                                                           
-      {                                                                                                
-	MakeCanvas("jet2", 1);                                                                                                                  
-      }                                                                                                                                     
-    // TC[1]->Clear("D"); //                                                                                                                  
-    Pad[1][0]->cd();                                                                                                                       
-    if (constituents_ncstsvscalolayer)                                                                                
-      {                                                                                                                                 
-	constituents_ncstsvscalolayer->SetTitle("Jet N Constituents vs Calo Layer");                                                                                  
-	constituents_ncstsvscalolayer->SetXTitle("N Constituents");                                                                              
-	constituents_ncstsvscalolayer->SetYTitle("Calo Layer");
-	constituents_ncstsvscalolayer->SetZTitle("Counts");
-	constituents_ncstsvscalolayer->DrawCopy("COLZ"); //2D histogram                                                               
-	gStyle->SetPalette(4, kBird);
-        gPad->UseCurrentStyle();
-        gPad->Update();
-        gPad->SetRightMargin(0.15);                                                                                                       
-      }                                                                                                                                   
-    Pad[1][1]->cd();                                                                                                                              
-    if (constituents_efracjetvscalolayer)                                                                                                        
-      {                                                                                                                                             
-	constituents_efracjetvscalolayer->SetTitle("Jet E Fraction vs Calo Layer");                                                                 
-	constituents_efracjetvscalolayer->SetXTitle("Jet E Fraction");                                                                     
-	constituents_efracjetvscalolayer->SetYTitle("Calo Layer");
-	constituents_efracjetvscalolayer->SetZTitle("Counts");                                                                                       
-	constituents_efracjetvscalolayer->DrawCopy("COLZ"); //2D histogram                                                                                   
-	gStyle->SetPalette(4, kBird);
-        gPad->UseCurrentStyle();
-        gPad->Update();
-        gPad->SetRightMargin(0.15);
-      }
-    // canvas 3                                    
-    if (!gROOT->FindObject("jet3"))
-      {
-	MakeCanvas("jet3", 6);
-      }
-    Pad[6][0]->cd();
-    if (constituents_efracjet_cemc)
-      {
-	constituents_efracjet_cemc->SetTitle("Jet E Fraction in CEMC");
-	constituents_efracjet_cemc->SetXTitle("Jet E fraction");
-	constituents_efracjet_cemc->SetYTitle("Counts");
-	constituents_efracjet_cemc->DrawCopy("COLZ");
-	gStyle->SetPalette(4, kBird);
-	gPad->UseCurrentStyle();
-	gPad->Update();
-	gPad->SetRightMargin(0.15);
-      }
-    Pad[6][1]->cd();
-    if (constituents_efracjet_ihcal)
-      {
-	constituents_efracjet_ihcal->SetTitle("Jet Fraction in IHCal");
-	constituents_efracjet_ihcal->SetXTitle("Jet E Fraction");
-	constituents_efracjet_ihcal->SetYTitle("Counts");
-	constituents_efracjet_ihcal->DrawCopy("COLZ");
-	gStyle->SetPalette(4, kBird);
-	gPad->UseCurrentStyle();
-	gPad->Update();
-	gPad->SetRightMargin(0.15);
-      }
-    Pad[6][2]->cd();
-    if (constituents_efracjet_ohcal)
-      {
-	constituents_efracjet_ohcal->SetTitle("Jet Fraction in OHCal");
-	constituents_efracjet_ohcal->SetXTitle("Jet E Fraction");
-	constituents_efracjet_ohcal->SetYTitle("Counts");
-	constituents_efracjet_ohcal->DrawCopy("COLZ");
-	gStyle->SetPalette(4, kBird);
-	gPad->UseCurrentStyle();
-	gPad->Update();
-	gPad->SetRightMargin(0.15);
-      }
-    TText PrintRun;
-    PrintRun.SetTextFont(62);
-    PrintRun.SetTextSize(0.04);
-    PrintRun.SetNDC();          // set to normalized coordinates                                                                                                   
-    PrintRun.SetTextAlign(23);  // center/top alignment                                                                              
-                          
-    // Generate run strings
-    std::ostringstream runnostream[6];
-    std::string runstring[6];
-    runnostream[0] << Name() << "_constituentsinjets_inclusive Run " << cl->RunNumber();
-    runstring[0] = runnostream[0].str();
-    runnostream[1] << Name() << "_constituentsinjets_mbdns1 Run " << cl->RunNumber();
-    runstring[1] = runnostream[1].str();
-    runnostream[2] << Name() << "_constituentsinjets_mbdnsjet1 Run " << cl->RunNumber();
-    runstring[2] = runnostream[2].str();
-    runnostream[3] << Name() << "_constituentsinjets_mbdnsjet2 Run " << cl->RunNumber();
-    runstring[3] = runnostream[3].str();
-    runnostream[4] << Name() << "_constituentsinjets_mbdnsjet3 Run " << cl->RunNumber();
-    runstring[4] = runnostream[4].str();
-    runnostream[5] << Name() << "_constituentsinjets_mbdnsjet4 Run " << cl->RunNumber();
-    runstring[5] = runnostream[5].str();
+  // form canvas name & if it doesn't exist yet, create it
+  const std::string cstName = "jetCsts_" + m_mapTrigToTag[trigToDraw] + "_" + m_mapResToTag[resToDraw];
+  if (!gROOT->FindObject(cstName.data()))
+  {
+    m_vecCstCanvas.back().push_back(nullptr);
+    m_vecCstRun.back().push_back(nullptr);
+    MakeCanvas(cstName, 9, m_vecCstCanvas.back().back(), m_vecCstRun.back().back(), m_vecCstPad.back().back());
+  }
 
-    // Loop over pads and add the corresponding runstring
-    for (int i = 0; i < 6; ++i) {
-      transparent[i]->cd();  // Set current pad
-      PrintRun.DrawText(0.5, 0.95, runstring[i].c_str());  // Adjust coordinates as needed
-      // Draw histograms here if needed
-      TC[i]->Update();  // Update the pad
-    }
-    return 0;
-}
-
- int JetDraw::DrawRho(const uint32_t trigToDraw /*const JetRes resToDraw*/)
-{
-  QADrawClient *cl = QADrawClient::instance();
-  // TCanvas* canvas = new TCanvas( /* etc */ );                                                                                                                                                        
-  TH1D *eventwiserho_rhoarea = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_rhoarea")));
-  TH1D *eventwiserho_rhomult = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_rhomult")));
-  TH1D *eventwiserho_sigmaarea = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_sigmaarea")));
-  TH1D *eventwiserho_sigmamult = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_sigmamult")));
-
-  //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
-  //m_vecCanvas[trigToDraw].push_back(canvas);
-
-  // canvas 1
-  if (!gROOT->FindObject("eventwiserho"))
-    {
-      MakeCanvas("eventwiserho", 2);
-    }
-  /* TC[2]->Clear("D"); */
-  Pad[2][0]->cd();
-  if (eventwiserho_rhoarea)
-    {
-      eventwiserho_rhoarea->SetTitle("Rho Area");
-      eventwiserho_rhoarea->SetXTitle("#rho*A");
-      eventwiserho_rhoarea->SetYTitle("Counts");
-      // eventwiserho_rhoarea->GetXaxis()->SetNdivisions(505);
-      // eventwiserho_rhoarea->GetXaxis()->SetRangeUser(-1, 15);
-      eventwiserho_rhoarea->DrawCopy("COLZ");
-      gPad->UseCurrentStyle();
-      gPad->SetLogy();
-      gPad->SetLogz();
-      gPad->SetRightMargin(0.15);
-    }
+  m_vecCstPad.back().back().at(0)->cd();
+  if (constituents_ncsts_cemc)
+  {
+    constituents_ncsts_cemc->SetTitle("Jet N Constituents in CEMC");
+    constituents_ncsts_cemc->SetXTitle("N Constituents");
+    constituents_ncsts_cemc->SetYTitle("Counts");
+    constituents_ncsts_cemc->GetXaxis()->SetNdivisions(505);
+    constituents_ncsts_cemc->GetXaxis()->SetRangeUser(-1, 15);
+    constituents_ncsts_cemc->DrawCopy("HIST"); //1D histogram
+    gPad->UseCurrentStyle();
+    gPad->SetLogy();
+    //gPad->SetLogz() //No z axis
+    gPad->SetRightMargin(0.15);
+  }
   else
-    {                              
-      return -1;
-    }
-  Pad[2][1]->cd();
-  if (eventwiserho_rhomult)
-    {
-      eventwiserho_rhomult->SetTitle("#rho Multiplicity");
-      eventwiserho_rhomult->SetXTitle("#rho_{mult}");
-      eventwiserho_rhomult->SetYTitle("Counts");
-      eventwiserho_rhomult->DrawCopy("COLZ");
-      gPad->UseCurrentStyle();
-      gPad->SetRightMargin(0.15);
-    }
-  Pad[2][2]->cd();
-  if (eventwiserho_sigmaarea)
-    {
-      eventwiserho_sigmaarea->SetTitle("Sigma Area");
-      eventwiserho_sigmaarea->SetXTitle("#sigma*A");
-      eventwiserho_sigmaarea->SetYTitle("Counts");
-      // eventwiserho_sigmaarea->GetXaxis()->SetNdivisions(505);
-      eventwiserho_sigmaarea->DrawCopy("COLZ");
-      gPad->UseCurrentStyle();
-      gPad->SetRightMargin(0.15);
-    }
-  Pad[2][3]->cd();
-  if (eventwiserho_sigmamult)
-    {
-      eventwiserho_sigmamult->SetTitle("#sigma Multiplicity");
-      eventwiserho_sigmamult->SetXTitle("#sigma_{mult}");
-      eventwiserho_sigmamult->SetYTitle("Counts");
-      eventwiserho_sigmamult->DrawCopy("COLZ");
-      gPad->UseCurrentStyle();
-    }
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(1)->cd();
+  if (constituents_ncsts_ihcal)
+  {
+    constituents_ncsts_ihcal->SetTitle("Jet N Constituents in IHCal");
+    constituents_ncsts_ihcal->SetXTitle("N Constituents");
+    constituents_ncsts_ihcal->SetYTitle("Counts");
+    constituents_ncsts_ihcal->GetXaxis()->SetNdivisions(505);
+    constituents_ncsts_ihcal->DrawCopy("HIST"); // 1D histogram
+    gPad->UseCurrentStyle();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(2)->cd();
+  if (constituents_ncsts_ohcal)
+  {
+    constituents_ncsts_ohcal->SetTitle("Jet N Constituents in OHCal");
+    constituents_ncsts_ohcal->SetXTitle("N Constituents");
+    constituents_ncsts_ohcal->SetYTitle("Counts");
+    constituents_ncsts_ohcal->GetXaxis()->SetNdivisions(505);
+    constituents_ncsts_ohcal->DrawCopy("HIST"); // 1D Histogram                             
+    gPad->UseCurrentStyle();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(3)->cd();
+  if (constituents_ncsts_total)
+  {
+    constituents_ncsts_total->SetTitle("Jet N Constituents");
+    constituents_ncsts_total->SetXTitle("N Constituents");
+    constituents_ncsts_total->GetXaxis()->SetNdivisions(505);
+    constituents_ncsts_total->SetYTitle("Counts");
+    constituents_ncsts_total->DrawCopy("HIST"); // 1D Histogram
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(4)->cd();
+  if (constituents_ncstsvscalolayer)
+  {
+    constituents_ncstsvscalolayer->SetTitle("Jet N Constituents vs Calo Layer");
+    constituents_ncstsvscalolayer->SetXTitle("N Constituents");
+    constituents_ncstsvscalolayer->SetYTitle("Calo Layer");
+    constituents_ncstsvscalolayer->SetZTitle("Counts");
+    constituents_ncstsvscalolayer->DrawCopy("COLZ"); // 2D Histogram
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(5)->cd();
+  if (constituents_efracjetvscalolayer)
+  {
+    constituents_efracjetvscalolayer->SetTitle("Jet E Fraction vs Calo Layer");
+    constituents_efracjetvscalolayer->SetXTitle("Jet E Fraction");
+    constituents_efracjetvscalolayer->SetYTitle("Calo Layer");
+    constituents_efracjetvscalolayer->SetZTitle("Counts");
+    constituents_efracjetvscalolayer->DrawCopy("COLZ"); // 2D Histogram
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(6)->cd();
+  if (constituents_efracjet_cemc)
+  {
+    constituents_efracjet_cemc->SetTitle("Jet E Fraction in CEMC");
+    constituents_efracjet_cemc->SetXTitle("Jet E fraction");
+    constituents_efracjet_cemc->SetYTitle("Counts");
+    constituents_efracjet_cemc->DrawCopy("HIST"); // 1D Histogram
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(7)->cd();
+  if (constituents_efracjet_ihcal)
+  {
+    constituents_efracjet_ihcal->SetTitle("Jet Fraction in IHCal");
+    constituents_efracjet_ihcal->SetXTitle("Jet E Fraction");
+    constituents_efracjet_ihcal->SetYTitle("Counts");
+    constituents_efracjet_ihcal->DrawCopy("HIST"); // 1D Histogram
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecCstPad.back().back().at(8)->cd();
+  if (constituents_efracjet_ohcal)
+  {
+    constituents_efracjet_ohcal->SetTitle("Jet Fraction in OHCal");
+    constituents_efracjet_ohcal->SetXTitle("Jet E Fraction");
+    constituents_efracjet_ohcal->SetYTitle("Counts");
+    constituents_efracjet_ohcal->DrawCopy("HIST");  // 1D Histogram
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
   TText PrintRun;
   PrintRun.SetTextFont(62);
   PrintRun.SetTextSize(0.04);
   PrintRun.SetNDC();          // set to normalized coordinates
   PrintRun.SetTextAlign(23);  // center/top alignment
-     
-  std::ostringstream runnostream[6];
-  std::string runstring[6];
-  runnostream[0] << Name() << "_eventwiserho_inclusive Run " << cl->RunNumber();
-  runstring[0] = runnostream[0].str();
-  runnostream[1] << Name() << "_eventwiserho_mbdns1 Run " << cl->RunNumber();
-  runstring[1] = runnostream[1].str();
-  runnostream[2] << Name() << "_eventwiserho_mbdnsjet1 Run " << cl->RunNumber();
-  runstring[2] = runnostream[2].str();
-  runnostream[3] << Name() << "_eventwiserho_mbdnsjet2 Run " << cl->RunNumber();
-  runstring[3] = runnostream[3].str();
-  runnostream[4] << Name() << "_eventwiserho_mbdnsjet3 Run " << cl->RunNumber();
-  runstring[4] = runnostream[4].str();
-  runnostream[5] << Name() << "_eventwiserho_mbdnsjet4 Run " << cl->RunNumber();
-  runstring[5] = runnostream[5].str();
-  
-  // Loop over pads and add the corresponding runstring                                                                                                                             
-  for (int i = 0; i < 6; ++i) {
-    transparent[i]->cd();  // Set current pad                              
-    PrintRun.DrawText(0.5, 0.95, runstring[i].c_str());  // Adjust coordinates as needed                                                                                                    
-    // Draw histograms here if needed                                                                                                                                                        
-    TC[i]->Update();  // Update the pad                                                                                                                                                      
+
+  // Generate run string from client
+  std::ostringstream runnostream;
+  runnostream << cl->RunNumber();
+
+  // prepend module name, component, trigger, and resolution
+  std::string runstring = Name();
+  runstring += "_JetCsts_";
+  runstring += m_mapTrigToName[trigToDraw];
+  runstring += "_";
+  runstring += m_mapResToName[resToDraw];
+  runstring += " Run ";
+  runstring += runnostream.str();
+
+  // add runstring to relevant pad
+  m_vecCstRun.back().back()->cd();
+  PrintRun.DrawText(0.5, 0.95, runstring.data());  // Adjust coordinates as needed
+  m_vecCstCanvas.back().back()->Update();  // Update the pad
+
+  // return w/o error
+  return 0;
+}
+
+int JetDraw::DrawRho(const uint32_t trigToDraw /*const JetRes resToDraw*/)
+{
+
+  // grab relevant histograms from draw client
+  QADrawClient *cl = QADrawClient::instance();
+
+  TH1D *eventwiserho_rhoarea = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_rhoarea")));
+  TH1D *eventwiserho_rhomult = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_rhomult")));
+  TH1D *eventwiserho_sigmaarea = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_sigmaarea")));
+  TH1D *eventwiserho_sigmamult = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_sigmamult")));
+
+  // form canvas name & if it doesn't exist yet, create it
+  const std::string rhoName = "evtRho_" + m_mapTrigToTag[trigToDraw];
+  if (!gROOT->FindObject(rhoName.data()))
+  {
+    m_vecRhoCanvas.push_back(nullptr);
+    m_vecRhoRun.push_back(nullptr);
+    MakeCanvas(rhoName, 4, m_vecRhoCanvas.back(), m_vecRhoRun.back(), m_vecRhoPad.back());
   }
+
+  m_vecRhoPad.back().at(0)->cd();
+  if (eventwiserho_rhoarea)
+  {
+    eventwiserho_rhoarea->SetTitle("Rho Area");
+    eventwiserho_rhoarea->SetXTitle("#rho*A");
+    eventwiserho_rhoarea->SetYTitle("Counts");
+    // eventwiserho_rhoarea->GetXaxis()->SetNdivisions(505);
+    // eventwiserho_rhoarea->GetXaxis()->SetRangeUser(-1, 15);
+    eventwiserho_rhoarea->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+    gPad->SetLogy();
+    gPad->SetLogz();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecRhoPad.back().at(1)->cd();
+  if (eventwiserho_rhomult)
+  {
+    eventwiserho_rhomult->SetTitle("#rho Multiplicity");
+    eventwiserho_rhomult->SetXTitle("#rho_{mult}");
+    eventwiserho_rhomult->SetYTitle("Counts");
+    eventwiserho_rhomult->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecRhoPad.back().at(2)->cd();
+  if (eventwiserho_sigmaarea)
+  {
+    eventwiserho_sigmaarea->SetTitle("Sigma Area");
+    eventwiserho_sigmaarea->SetXTitle("#sigma*A");
+    eventwiserho_sigmaarea->SetYTitle("Counts");
+    // eventwiserho_sigmaarea->GetXaxis()->SetNdivisions(505);
+    eventwiserho_sigmaarea->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecRhoPad.back().at(3)->cd();
+  if (eventwiserho_sigmamult)
+  {
+    eventwiserho_sigmamult->SetTitle("#sigma Multiplicity");
+    eventwiserho_sigmamult->SetXTitle("#sigma_{mult}");
+    eventwiserho_sigmamult->SetYTitle("Counts");
+    eventwiserho_sigmamult->DrawCopy("COLZ");
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+
+  // Generate run string from client
+  std::ostringstream runnostream;
+  runnostream << cl->RunNumber();
+
+  // prepend module name, component, trigger, and resolution
+  std::string runstring = Name();
+  runstring += "_EvtRho_";
+  runstring += m_mapTrigToName[trigToDraw];
+  runstring += " Run ";
+  runstring += runnostream.str();
+
+  // add runstring to relevant pad
+  m_vecRhoRun.back()->cd();
+  PrintRun.DrawText(0.5, 0.95, runstring.data());  // Adjust coordinates as needed
+  m_vecRhoCanvas.back()->Update();  // Update the pad
+
+  // return w/o error
   return 0;
 }
 
@@ -531,124 +599,135 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
     break;
   }
 
+  // grab relevant histograms from draw client
   QADrawClient *cl = QADrawClient::instance();
 
   TH2D *jetkinematiccheck_etavsphi = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] +std::string("_etavsphi_") + m_mapResToTag[resToDraw]));
-  TH2D *jetkinematiccheck_jetmassvseta = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jetmassvseta_") + m_mapResToTag[resToDraw]));         
+  TH2D *jetkinematiccheck_jetmassvseta = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jetmassvseta_") + m_mapResToTag[resToDraw]));
   TH2D *jetkinematiccheck_jetmassvspt = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jettmassvspt_") + m_mapResToTag[resToDraw]));
   TH2D *jetkinematiccheck_spectra = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_spectra_") + m_mapResToTag[resToDraw]));
-  
-  // map of resolution index to tag for TProfiles                                                                                                                                               
+
   TProfile *jetkinematiccheck_jetmassvseta_pfx = dynamic_cast<TProfile *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jetmassvseta_") + m_mapResToTag[resToDraw] + std::string("_pfx")));
   TProfile *jetkinematiccheck_jetmassvspt_pfx = dynamic_cast<TProfile *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jettmassvspt_") + m_mapResToTag[resToDraw] + std::string("_pfx")));
 
-  //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
-  //m_vecCanvas[trigToDraw].push_back(canvas);
-  
-  // canvas 1                                                                              
-  if (!gROOT->FindObject("jetkinematiccheck"))
-    {
-      MakeCanvas("jetkinematiccheck", 3);
-    }
-  Pad[3][0]->cd();
+  // form canvas name & if it doesn't exist yet, create it
+  const std::string kineName = "jetKinematics_" + m_mapTrigToTag[trigToDraw] + "_" + m_mapResToTag[resToDraw];
+  if (!gROOT->FindObject(kineName.data()))
+  {
+    m_vecKineCanvas.back().push_back(nullptr);
+    m_vecKineRun.back().push_back(nullptr);
+    MakeCanvas(kineName, 4, m_vecKineCanvas.back().back(), m_vecKineRun.back().back(), m_vecKinePad.back().back());
+  }
+
+  m_vecKinePad.back().back().at(0)->cd();
   if (jetkinematiccheck_etavsphi)
-    {
-      jetkinematiccheck_etavsphi->SetTitle("Jet #eta vs #phi");
-      jetkinematiccheck_etavsphi->SetXTitle("Jet #eta");
-      jetkinematiccheck_etavsphi->SetYTitle("Jet #phi");
-      jetkinematiccheck_etavsphi->SetZTitle("Counts");
-      // jetkinematiccheck_etavsphi->GetXaxis()->SetNdivisions(505);
-      // jetkinematiccheck_etavsphi->GetXaxis()->SetRangeUser(-1, 15);
-      jetkinematiccheck_etavsphi->DrawCopy("COLZ");
-      gStyle->SetPalette(4, kBird);
-      gPad->UseCurrentStyle();
-      gPad->Update();
-      gPad->SetRightMargin(0.15);     
-    }
+  {
+    jetkinematiccheck_etavsphi->SetTitle("Jet #eta vs #phi");
+    jetkinematiccheck_etavsphi->SetXTitle("Jet #eta");
+    jetkinematiccheck_etavsphi->SetYTitle("Jet #phi");
+    jetkinematiccheck_etavsphi->SetZTitle("Counts");
+    // jetkinematiccheck_etavsphi->GetXaxis()->SetNdivisions(505);
+    // jetkinematiccheck_etavsphi->GetXaxis()->SetRangeUser(-1, 15);
+    jetkinematiccheck_etavsphi->DrawCopy("COLZ");  // 2D Histogram
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
   else
-    {                                                                         
-      return -1;
-    }
-  Pad[3][1]->cd();
-  if (jetkinematiccheck_jetmassvseta)
-    {
-      jetkinematiccheck_jetmassvseta->SetTitle("Jet Mass vs #eta");
-      jetkinematiccheck_jetmassvseta->SetXTitle("Jet Mass [GeV/c^{2}]");
-      jetkinematiccheck_jetmassvseta->SetYTitle("Jet #eta");
-      jetkinematiccheck_jetmassvseta->SetZTitle("Counts");
-      jetkinematiccheck_jetmassvseta->DrawCopy("COLZ");
-      gStyle->SetPalette(4, kBird);
-      gPad->UseCurrentStyle();
-      gPad->Update();
-      gPad->SetRightMargin(0.15);
-    }
-  Pad[3][2]->cd();
-  if (jetkinematiccheck_jetmassvspt)
-    {
-      jetkinematiccheck_jetmassvspt->SetTitle("Jet Mass vs p_{T}");
-      jetkinematiccheck_jetmassvspt->SetXTitle("Jet Mass [GeV/c^{2}]");
-      jetkinematiccheck_jetmassvspt->SetYTitle("Jet p_{T} [GeV/c]");
-      jetkinematiccheck_jetmassvspt->SetZTitle("Counts");
-      jetkinematiccheck_jetmassvspt->DrawCopy("COLZ");
-      gStyle->SetPalette(4, kBird);
-      gPad->UseCurrentStyle();
-      gPad->Update();
-      gPad->SetRightMargin(0.15);
-    }
-  Pad[3][3]->cd();
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecKinePad.back().back().at(1)->cd();
+  if (jetkinematiccheck_jetmassvseta && jetkinematiccheck_jetmassvseta_pfx)
+  {
+    jetkinematiccheck_jetmassvseta->SetTitle("Jet Mass vs #eta");
+    jetkinematiccheck_jetmassvseta->SetXTitle("Jet Mass [GeV/c^{2}]");
+    jetkinematiccheck_jetmassvseta->SetYTitle("Jet #eta");
+    jetkinematiccheck_jetmassvseta->SetZTitle("Counts");
+    jetkinematiccheck_jetmassvseta->DrawCopy("COLZ");  // 2D Histogram
+    jetkinematiccheck_jetmassvseta_pfx->SetTitle("Jet Mass vs #eta");
+    jetkinematiccheck_jetmassvseta_pfx->SetXTitle("Jet Mass [GeV/c^{2}]");
+    jetkinematiccheck_jetmassvseta_pfx->SetYTitle("Jet #eta");
+    jetkinematiccheck_jetmassvseta_pfx->SetZTitle("Counts");
+    jetkinematiccheck_jetmassvseta_pfx->DrawCopy("SAME");  // Profile
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecKinePad.back().back().at(2)->cd();
+  if (jetkinematiccheck_jetmassvspt && jetkinematiccheck_jetmassvspt_pfx)
+  {
+    jetkinematiccheck_jetmassvspt->SetTitle("Jet Mass vs p_{T}");
+    jetkinematiccheck_jetmassvspt->SetXTitle("Jet Mass [GeV/c^{2}]");
+    jetkinematiccheck_jetmassvspt->SetYTitle("Jet p_{T} [GeV/c]");
+    jetkinematiccheck_jetmassvspt->SetZTitle("Counts");
+    jetkinematiccheck_jetmassvspt->DrawCopy("COLZ");  // 2D Histogram
+    jetkinematiccheck_jetmassvspt_pfx->SetTitle("Jet Mass vs p_{T}");
+    jetkinematiccheck_jetmassvspt_pfx->SetXTitle("Jet Mass [GeV/c^{2}]");
+    jetkinematiccheck_jetmassvspt_pfx->SetYTitle("Jet p_{T} [GeV/c]");
+    jetkinematiccheck_jetmassvspt_pfx->SetZTitle("Counts");
+    jetkinematiccheck_jetmassvspt_pfx->DrawCopy("SAME");  // Profile
+    gStyle->SetPalette(4, kBird);
+    gPad->UseCurrentStyle();
+    gPad->Update();
+    gPad->SetRightMargin(0.15);
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
+  m_vecKinePad.back().back().at(3)->cd();
   if (jetkinematiccheck_spectra)
-    {
-      jetkinematiccheck_spectra->SetTitle("Jet Spectra");
-      jetkinematiccheck_spectra->SetXTitle("p_{T,Jet} [GeV/c]");
-      jetkinematiccheck_spectra->SetYTitle("Counts");
-      jetkinematiccheck_spectra->DrawCopy("HIST");
-      gPad->UseCurrentStyle();
-    }
-  Pad[3][4]->cd();
-  if (jetkinematiccheck_jetmassvseta_pfx)
-    {
-      jetkinematiccheck_jetmassvseta_pfx->SetTitle("Average Jet Mass vs #eta");
-      jetkinematiccheck_jetmassvseta_pfx->SetXTitle("#eta");
-      jetkinematiccheck_jetmassvseta_pfx->SetYTitle("Average Jet Mass [GeV/c^{2}])");
-      jetkinematiccheck_jetmassvseta_pfx->DrawCopy("HIST");
-      gPad->UseCurrentStyle();
-    }
-  Pad[3][5]->cd();
-  if (jetkinematiccheck_jetmassvspt_pfx)
-    {
-      jetkinematiccheck_jetmassvspt_pfx->SetTitle("Average Jet Mass vs p_{T}");
-      jetkinematiccheck_jetmassvspt_pfx->SetXTitle("Average Jet Mass [GeV/c^{2}]");
-      jetkinematiccheck_jetmassvspt_pfx->SetYTitle("p_{T} [GeV/c]");
-      jetkinematiccheck_jetmassvspt_pfx->DrawCopy("HIST");
-      gPad->UseCurrentStyle();
-    }
+  {
+    jetkinematiccheck_spectra->SetTitle("Jet Spectra");
+    jetkinematiccheck_spectra->SetXTitle("p_{T,Jet} [GeV/c]");
+    jetkinematiccheck_spectra->SetYTitle("Counts");
+    jetkinematiccheck_spectra->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    // histogram is missing
+    return -1;
+  }
+
   TText PrintRun;
   PrintRun.SetTextFont(62);
   PrintRun.SetTextSize(0.04);
   PrintRun.SetNDC();  // set to normalized 
   PrintRun.SetTextAlign(23);  // center/top alignment
-                               
-  // Generate run strings		     
-  std::ostringstream runnostream[6];
-  std::string runstring[6];
-  runnostream[0] << Name() << "_jetkinematiccheck_inclusive Run " << cl->RunNumber();
-  runstring[0] = runnostream[0].str();
-  runnostream[1] << Name() << "_jetkinematiccheck_mbdns1 Run " << cl->RunNumber();
-  runstring[1] = runnostream[1].str();
-  runnostream[2] << Name() << "_jetkinematiccheck_mbdnsjet1 Run " << cl->RunNumber();
-  runstring[2] = runnostream[2].str();
-  runnostream[3] << Name() << "_jetkinematiccheck_mbdnsjet2 Run " << cl->RunNumber();
-  runstring[3] = runnostream[3].str();
-  runnostream[4] << Name() << "_jetkinematiccheck_mbdnsjet3 Run " << cl->RunNumber();
-  runstring[4] = runnostream[4].str();
-  runnostream[5] << Name() << "_jetkinematiccheck_mbdnsjet4 Run " << cl->RunNumber();
-  runstring[5] = runnostream[5].str();
-  
-  for (int i = 0; i < 6; ++i) {
-    transparent[i]->cd();  // Set current pad
-    PrintRun.DrawText(0.5, 0.95, runstring[i].c_str());  // Adjust coordinates as 
-    TC[i]->Update();  // Update 
-  }
+
+  // Generate run string from client
+  std::ostringstream runnostream;
+  runnostream << cl->RunNumber();
+
+  // prepend module name, component, trigger, and resolution
+  std::string runstring = Name();
+  runstring += "_JetKinematics_";
+  runstring += m_mapTrigToName[trigToDraw];
+  runstring += "_";
+  runstring += m_mapResToName[resToDraw];
+  runstring += " Run ";
+  runstring += runnostream.str();
+
+  // add runstring to relevant pad
+  m_vecKineRun.back().back()->cd();
+  PrintRun.DrawText(0.5, 0.95, runstring.data());  // Adjust coordinates as needed
+  m_vecKineCanvas.back().back()->Update();  // Update the pad
+
+  // return w/o error
   return 0;
 }
 
@@ -673,27 +752,30 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
     break;
   }
   
+  // grab relevant histograms from draw client
   QADrawClient *cl = QADrawClient::instance();
+
   TH2F *jetseedcount_rawetavsphi = dynamic_cast<TH2F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawetavsphi")));
   TH1F *jetseedcount_rawpt = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawpt")));
   TH1F *jetseedcount_rawptall = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawptall")));
   TH1F *jetseedcount_rawseedcount = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawseedcount")));
   TH2F *jetseedcount_subetavsphi = dynamic_cast<TH2F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subetavsphi")));
   TH1F *jetseedcount_subpt = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subpt")));
-  TH1F *jetseedcount_subptall = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subptall")));  
+  TH1F *jetseedcount_subptall = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subptall")));
   TH1F *jetseedcount_subseedcount = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subseedcount")));
-  
-  //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
-  //m_vecCanvas[trigToDraw].push_back(canvas);
 
-  //canvas 1                                                                                  
-  if (!gROOT->FindObject("jetseedcount1"))
-    {
-      MakeCanvas("jetseedcount1", 4);
-    }
-  Pad[4][0]->cd();
+  // form canvas name & if it doesn't exist yet, create it
+  const std::string seedName = "jetSeeds_" + m_mapTrigToTag[trigToDraw] + "_" + m_mapResToTag[resToDraw];
+  if (!gROOT->FindObject(seedName.data()))
+  {
+    m_vecSeedCanvas.back().push_back(nullptr);
+    m_vecSeedRun.back().push_back(nullptr);
+    MakeCanvas(seedName, 8, m_vecSeedCanvas.back().back(), m_vecSeedRun.back().back(), m_vecSeedPad.back().back());
+  }
+
+  m_vecSeedPad.back().back().at(0)->cd();
   if (jetseedcount_rawetavsphi)
-    {
+  {
       jetseedcount_rawetavsphi->SetLineColor(kBlue);
       jetseedcount_rawetavsphi->GetXaxis()->SetRangeUser(0.0, 12000);
       jetseedcount_rawetavsphi->SetTitle("Raw Seed #eta vs #phi");
@@ -701,116 +783,141 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
       jetseedcount_rawetavsphi->SetYTitle("Jet #phi_{raw} [Rads.]");
       jetseedcount_rawetavsphi->SetZTitle("Counts");
       // jetseedcount_rawetavsphi->GetXaxis()->SetNdivisions(505);
-      jetseedcount_rawetavsphi->DrawCopy();
+      jetseedcount_rawetavsphi->DrawCopy("COLZ");  // 2D Histogram
       gPad->UseCurrentStyle();
-    }
+  }
   else
-    {                                                                            
-      return -1;
-    }
-  Pad[4][1]->cd();
-  if (jetseedcount_rawpt)
-    {
-      jetseedcount_rawpt->SetTitle("Raw p_{T}");
-      jetseedcount_rawpt->SetXTitle("Jet p_{T,Raw} [GeV]");
-      jetseedcount_rawpt->SetYTitle("Counts");
-      jetseedcount_rawpt->DrawCopy("");
-      gPad->UseCurrentStyle();
-    }
-  Pad[4][2]->cd();
-  if (jetseedcount_rawptall)
-    {
-      jetseedcount_rawptall->SetTitle("Raw p_{T} (all jet seeds)");
-      jetseedcount_rawptall->SetXTitle("Jet p_{T,all seed} [GeV]");
-      jetseedcount_rawptall->SetYTitle("Counts");
-      jetseedcount_rawptall->DrawCopy("");
-      gPad->UseCurrentStyle();
-    }
-  Pad[4][3]->cd();
-  if (jetseedcount_rawseedcount)
-    {
-      jetseedcount_rawseedcount->SetTitle("Raw Seed Count per Event");
-      jetseedcount_rawseedcount->SetXTitle("Raw Seed Count per Event");
-      jetseedcount_rawseedcount->SetYTitle("Counts");
-      jetseedcount_rawseedcount->DrawCopy("");
-      gPad->UseCurrentStyle();
-    }
+  {
+    // histogram missing
+    return -1;
+  }
 
-  //canvas 2                                                                                                                                                                                  
-  if (!gROOT->FindObject("jetseedcount2"))
-    {
-      MakeCanvas("jetseedcount2", 5);
-    }
-  Pad[5][0]->cd();
-  if (jetseedcount_subetavsphi)
-    {
-      jetseedcount_subetavsphi->SetLineColor(kBlue);
-      // jetseedcount_subetavsphi->GetXaxis()->SetRangeUser(0.0, 12000);
-      jetseedcount_subetavsphi->SetTitle("Sub-seed #eta vs #phi");
-      jetseedcount_subetavsphi->SetXTitle("Jet #eta_{subseed} [Rads.]");
-      jetseedcount_subetavsphi->SetYTitle("Jet #phi_{subseed} [Rads.]");
-      jetseedcount_subetavsphi->SetZTitle("Counts");
-      // jetseedcount_subetavsphi->GetXaxis()->SetNdivisions(505);
-      jetseedcount_subetavsphi->DrawCopy();
-      gPad->UseCurrentStyle();
-    }
+  m_vecSeedPad.back().back().at(1)->cd();
+  if (jetseedcount_rawpt)
+  {
+    jetseedcount_rawpt->SetTitle("Raw p_{T}");
+    jetseedcount_rawpt->SetXTitle("Jet p_{T,Raw} [GeV]");
+    jetseedcount_rawpt->SetYTitle("Counts");
+    jetseedcount_rawpt->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+  }
   else
-    {
-      return -1;
-    }
-  Pad[5][1]->cd();
+  {
+    // histogram missing
+    return -1;
+  }
+
+  m_vecSeedPad.back().back().at(2)->cd();
+  if (jetseedcount_rawptall)
+  {
+    jetseedcount_rawptall->SetTitle("Raw p_{T} (all jet seeds)");
+    jetseedcount_rawptall->SetXTitle("Jet p_{T,all seed} [GeV]");
+    jetseedcount_rawptall->SetYTitle("Counts");
+    jetseedcount_rawptall->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    // histogram missing
+    return -1;
+  }
+
+  m_vecSeedPad.back().back().at(3)->cd();
+  if (jetseedcount_rawseedcount)
+  {
+    jetseedcount_rawseedcount->SetTitle("Raw Seed Count per Event");
+    jetseedcount_rawseedcount->SetXTitle("Raw Seed Count per Event");
+    jetseedcount_rawseedcount->SetYTitle("Counts");
+    jetseedcount_rawseedcount->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    // histogram missing
+    return -1;
+  }
+
+  m_vecSeedPad.back().back().at(4)->cd();
+  if (jetseedcount_subetavsphi)
+  {
+    jetseedcount_subetavsphi->SetLineColor(kBlue);
+    // jetseedcount_subetavsphi->GetXaxis()->SetRangeUser(0.0, 12000);
+    jetseedcount_subetavsphi->SetTitle("Sub-seed #eta vs #phi");
+    jetseedcount_subetavsphi->SetXTitle("Jet #eta_{subseed} [Rads.]");
+    jetseedcount_subetavsphi->SetYTitle("Jet #phi_{subseed} [Rads.]");
+    jetseedcount_subetavsphi->SetZTitle("Counts");
+    // jetseedcount_subetavsphi->GetXaxis()->SetNdivisions(505);
+    jetseedcount_subetavsphi->DrawCopy("COLZ");  // 2D Histogram
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    return -1;
+  }
+
+  m_vecSeedPad.back().back().at(5)->cd();
   if (jetseedcount_subpt)
-    {
-      jetseedcount_subpt->SetTitle("Sub. p_{T}");
-      jetseedcount_subpt->SetXTitle("Jet p_{T,sub.} [GeV]");
-      jetseedcount_subpt->SetYTitle("Counts");
-      jetseedcount_subpt->DrawCopy("");
-      gPad->UseCurrentStyle();
-    }
-  Pad[5][2]->cd();
+  {
+    jetseedcount_subpt->SetTitle("Sub. p_{T}");
+    jetseedcount_subpt->SetXTitle("Jet p_{T,sub.} [GeV]");
+    jetseedcount_subpt->SetYTitle("Counts");
+    jetseedcount_subpt->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    return -1;
+  }
+
+  m_vecSeedPad.back().back().at(6)->cd();
   if (jetseedcount_subptall)
-    {
-      jetseedcount_subptall->SetTitle("Sub. p_{T} (all jet seeds)");
-      jetseedcount_subptall->SetXTitle("Jet p_{T, all-sub.} [GeV]");
-      jetseedcount_subptall->SetYTitle("Counts");
-      jetseedcount_subptall->DrawCopy("");
-      gPad->UseCurrentStyle();
-    }
-  Pad[5][3]->cd();
+  {
+    jetseedcount_subptall->SetTitle("Sub. p_{T} (all jet seeds)");
+    jetseedcount_subptall->SetXTitle("Jet p_{T, all-sub.} [GeV]");
+    jetseedcount_subptall->SetYTitle("Counts");
+    jetseedcount_subptall->DrawCopy("HIST");  // 1D Histogram
+    gPad->UseCurrentStyle();
+  }
+  else
+  {
+    return -1;
+  }
+
+  m_vecSeedPad.back().back().at(7)->cd();
   if (jetseedcount_subseedcount)
-    {
-      jetseedcount_subseedcount->SetTitle("Sub Seed Count per Event");
-      jetseedcount_subseedcount->SetXTitle("Sub Seed Count per Event");
-      jetseedcount_subseedcount->SetYTitle("Counts");
-      jetseedcount_subseedcount->DrawCopy("");
-      gPad->UseCurrentStyle();
-    }
+  {
+    jetseedcount_subseedcount->SetTitle("Sub Seed Count per Event");
+    jetseedcount_subseedcount->SetXTitle("Sub Seed Count per Event");
+    jetseedcount_subseedcount->SetYTitle("Counts");
+    jetseedcount_subseedcount->DrawCopy("");
+    gPad->UseCurrentStyle();
+  }
+
   TText PrintRun;
   PrintRun.SetTextFont(62);
   PrintRun.SetTextSize(0.04);
-  PrintRun.SetNDC();  // set to normalized                                                                                                                                                                                                                                     
-  PrintRun.SetTextAlign(23);  // center/top alignment                                                                                                                                                                                                                           
-  // Generate run strings                                                                                                                                                                      
-  std::ostringstream runnostream[6];
-  std::string runstring[6];
-  runnostream[0] << Name() << "_jetseedcount_inclusive Run " << cl->RunNumber();
-  runstring[0] = runnostream[0].str();
-  runnostream[1] << Name() << "_jetseedcount_mbdns1 Run " << cl->RunNumber();
-  runstring[1] = runnostream[1].str();
-  runnostream[2] << Name() << "_jetseedcount_mbdnsjet1 Run " << cl->RunNumber();
-  runstring[2] = runnostream[2].str();
-  runnostream[3] << Name() << "_jetseedcount_mbdnsjet2 Run " << cl->RunNumber();
-  runstring[3] = runnostream[3].str();
-  runnostream[4] << Name() << "_jetseedcount_mbdnsjet3 Run " << cl->RunNumber();
-  runstring[4] = runnostream[4].str();
-  runnostream[5] << Name() << "_jetseedcount_mbdnsjet4 Run " << cl->RunNumber();
-  runstring[5] = runnostream[5].str();
+  PrintRun.SetNDC();  // set to normalized
+  PrintRun.SetTextAlign(23);  // center/top alignment
 
-  for (int i = 0; i < 6; ++i) {
-    transparent[i]->cd();  // Set current pad                                                                                                                                                 
-    PrintRun.DrawText(0.5, 0.95, runstring[i].c_str());  // Adjust coordinates as                                                                                                             
-    TC[i]->Update();  // Update                                                                                                                                                                
-  }
+  // Generate run string from client
+  std::ostringstream runnostream;
+  runnostream << cl->RunNumber();
+
+  // prepend module name, component, trigger, and resolution
+  std::string runstring = Name();
+  runstring += "_JetSeeds_";
+  runstring += m_mapTrigToName[trigToDraw];
+  runstring += "_";
+  runstring += m_mapResToName[resToDraw];
+  runstring += " Run ";
+  runstring += runnostream.str();
+
+  // add runstring to relevant pad
+  m_vecSeedRun.back().back()->cd();
+  PrintRun.DrawText(0.5, 0.95, runstring.data());  // Adjust coordinates as needed
+  m_vecSeedCanvas.back().back()->Update();  // Update the pad
+
+  // return w/o error
   return 0;
 }
 

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -42,8 +42,8 @@ JetDraw::~JetDraw()
   return;
 }
 
-int JetDraw::MakeHtml(const std::string &what) {
-  int iret = 0;
+int JetDraw::MakeHtml(const std::string &what)
+{
   const int drawError = Draw(what);  // Call to Draw
   if (drawError) {
     return drawError;  // Return if there is an error in Draw
@@ -85,7 +85,9 @@ int JetDraw::MakeHtml(const std::string &what) {
       cl->CanvasToPng(m_vecSeedCanvas[iTrigToDraw][iResToDraw], pngSeed);
     }
   }
-  return iret;  // Return after processing all triggers and resolutions
+
+  // return w/o error
+  return 0;
 }
 
 int JetDraw::Draw(const std::string &what)
@@ -115,7 +117,7 @@ int JetDraw::Draw(const std::string &what)
      // draw rho plots
      if  (what == "ALL" || what == "RHO")
      {
-       iret += DrawRho(trigToDraw);
+       iret = DrawRho(trigToDraw);
        ++idraw;
      }
 
@@ -131,21 +133,21 @@ int JetDraw::Draw(const std::string &what)
        // draw constituent plots
        if (what == "ALL" || what == "CONTSTITUENTS")
        {
-	 iret += DrawConstituents(trigToDraw, static_cast<JetRes>(resToDraw));
+	 iret = DrawConstituents(trigToDraw, static_cast<JetRes>(resToDraw));
 	 ++idraw;
        }
 
        // draw kinematic plots
        if (what == "ALL" || what == "KINEMATICCHECK")
        {
-         iret += DrawJetKinematics(trigToDraw, static_cast<JetRes>(resToDraw));
+         iret = DrawJetKinematics(trigToDraw, static_cast<JetRes>(resToDraw));
          ++idraw;
        }
 
        // draw seed plots
        if (what == "ALL" || what == "SEEDCOUNT")
        {
-         iret += DrawJetSeed(trigToDraw, static_cast<JetRes>(resToDraw));
+         iret = DrawJetSeed(trigToDraw, static_cast<JetRes>(resToDraw));
          ++idraw;
        }
      }
@@ -154,8 +156,10 @@ int JetDraw::Draw(const std::string &what)
    if (!idraw)
    {
      std::cout << " Unimplemented Drawing option: " << what << std::endl;
-     iret = -1;
+     return -1;
    }
+
+   // should return -1 if error, 0 otherwise
    return iret;
 }
  

--- a/subsystems/jets/JetDraw.cc
+++ b/subsystems/jets/JetDraw.cc
@@ -52,6 +52,9 @@ int JetDraw::MakeHtml(const std::string &what) {
     return drawError;  // Return if there is an error in Draw
   }
 
+  // instantiate draw client
+  QADrawClient *cl = QADrawClient::instance();
+
   // loop over triggers to draw
   for (std::size_t iTrigToDraw = 0; iTrigToDraw < m_vecTrigToDraw.size(); ++iTrigToDraw) {
 
@@ -104,7 +107,7 @@ int JetDraw::Draw(const std::string &what)
    for (uint32_t trigToDraw : m_vecTrigToDraw) { // loop over triggers
    
      // reserve space for each resolution to draw
-     m_vecCanvas[iTrig].resize( m_resToDraw.size() );
+     /* TODO may or may not need */
      ++iTrig;
      
      if  (what == "ALL" || what == "RHO") {
@@ -234,15 +237,15 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
   }
 
   QADrawClient *cl = QADrawClient::instance();
-  TH1D *constituents_ncsts_cemc = dynamic_cast<TH1D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_cemc")));
-  TH1D *constituents_ncsts_ihcal = dynamic_cast<TH1D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_ihcal")));
-  TH1D *constituents_ncsts_ohcal = dynamic_cast<TH1D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_ohcal")));
-  TH1D *constituents_ncsts_total = dynamic_cast<TH1D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_total")));
-  TH2D *constituents_ncstsvscalolayer = dynamic_cast<TH2D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncstsvscalolayer")));
-  TH1D *constituents_efracjet_cemc = dynamic_cast<TH1D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjet_cemc")));
-  TH1D *constituents_efracjet_ihcal = dynamic_cast<TH1D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjet_ihcal")));
-  TH1D *constituents_efracjet_ohcal = dynamic_cast<TH1D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjet_ohcal")));
-  TH2D *constituents_efracjetvscalolayer = dynamic_cast<TH2D *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjetcscalolayer")));
+  TH1D *constituents_ncsts_cemc = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_cemc")));
+  TH1D *constituents_ncsts_ihcal = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_ihcal")));
+  TH1D *constituents_ncsts_ohcal = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_ohcal")));
+  TH1D *constituents_ncsts_total = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncsts_total")));
+  TH2D *constituents_ncstsvscalolayer = dynamic_cast<TH2D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_ncstsvscalolayer")));
+  TH1D *constituents_efracjet_cemc = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjet_cemc")));
+  TH1D *constituents_efracjet_ihcal = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjet_ihcal")));
+  TH1D *constituents_efracjet_ohcal = dynamic_cast<TH1D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjet_ohcal")));
+  TH2D *constituents_efracjetvscalolayer = dynamic_cast<TH2D *>(cl->getHisto(m_constituent_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_efracjetcscalolayer")));
 
   //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
   //m_vecCanvas[trigToDraw].push_back(canvas);
@@ -414,10 +417,10 @@ int JetDraw::DrawConstituents(const uint32_t trigToDraw, const JetRes resToDraw)
 {
   QADrawClient *cl = QADrawClient::instance();
   // TCanvas* canvas = new TCanvas( /* etc */ );                                                                                                                                                        
-  TH1D *eventwiserho_rhoarea = dynamic_cast<TH1D *>(cl->getHisto(histprefix1 + m_mapTrigToTag[trigToDraw] + std::string("_rhoarea")));
-  TH1D *eventwiserho_rhomult = dynamic_cast<TH1D *>(cl->getHisto(histprefix1 + m_mapTrigToTag[trigToDraw] + std::string("_rhomult")));
-  TH1D *eventwiserho_sigmaarea = dynamic_cast<TH1D *>(cl->getHisto(histprefix1 + m_mapTrigToTag[trigToDraw] + std::string("_sigmaarea")));
-  TH1D *eventwiserho_sigmamult = dynamic_cast<TH1D *>(cl->getHisto(histprefix1 + m_mapTrigToTag[trigToDraw] + std::string("_sigmamult")));
+  TH1D *eventwiserho_rhoarea = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_rhoarea")));
+  TH1D *eventwiserho_rhomult = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_rhomult")));
+  TH1D *eventwiserho_sigmaarea = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_sigmaarea")));
+  TH1D *eventwiserho_sigmamult = dynamic_cast<TH1D *>(cl->getHisto(m_rho_prefix + m_mapTrigToTag[trigToDraw] + std::string("_sigmamult")));
 
   //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
   //m_vecCanvas[trigToDraw].push_back(canvas);
@@ -530,14 +533,14 @@ int JetDraw::DrawJetKinematics(const uint32_t trigToDraw, const JetRes resToDraw
 
   QADrawClient *cl = QADrawClient::instance();
 
-  TH2D *jetkinematiccheck_etavsphi = dynamic_cast<TH2D *>(cl->getHisto(histprefix2 + m_mapTrigToTag[trigToDraw] +std::string("_etavsphi_") + m_mapResToTag[resToDraw]));
-  TH2D *jetkinematiccheck_jetmassvseta = dynamic_cast<TH2D *>(cl->getHisto(histprefix2 + m_mapTrigToTag[trigToDraw] + std::string("_jetmassvseta_") + m_mapResToTag[resToDraw]));         
-  TH2D *jetkinematiccheck_jetmassvspt = dynamic_cast<TH2D *>(cl->getHisto(histprefix2 + m_mapTrigToTag[trigToDraw] + std::string("_jettmassvspt_") + m_mapResToTag[resToDraw]));
-  TH2D *jetkinematiccheck_spectra = dynamic_cast<TH2D *>(cl->getHisto(histprefix2 + m_mapTrigToTag[trigToDraw] + std::string("_spectra_") + m_mapResToTag[resToDraw]));
+  TH2D *jetkinematiccheck_etavsphi = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] +std::string("_etavsphi_") + m_mapResToTag[resToDraw]));
+  TH2D *jetkinematiccheck_jetmassvseta = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jetmassvseta_") + m_mapResToTag[resToDraw]));         
+  TH2D *jetkinematiccheck_jetmassvspt = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jettmassvspt_") + m_mapResToTag[resToDraw]));
+  TH2D *jetkinematiccheck_spectra = dynamic_cast<TH2D *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_spectra_") + m_mapResToTag[resToDraw]));
   
   // map of resolution index to tag for TProfiles                                                                                                                                               
-  TProfile *jetkinematiccheck_jetmassvseta_pfx = dynamic_cast<TProfile *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + std::string("_jetmassvseta_") + m_mapResToTag[resToDraw] + std::string("_pfx")));
-  TProfile *jetkinematiccheck_jetmassvspt_pfx = dynamic_cast<TProfile *>(cl->getHisto(histprefix + m_mapTrigToTag[trigToDraw] + std::string("_jettmassvspt_") + m_mapResToTag[resToDraw] + std::string("_pfx")));
+  TProfile *jetkinematiccheck_jetmassvseta_pfx = dynamic_cast<TProfile *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jetmassvseta_") + m_mapResToTag[resToDraw] + std::string("_pfx")));
+  TProfile *jetkinematiccheck_jetmassvspt_pfx = dynamic_cast<TProfile *>(cl->getHisto(m_kinematic_prefix + m_mapTrigToTag[trigToDraw] + std::string("_jettmassvspt_") + m_mapResToTag[resToDraw] + std::string("_pfx")));
 
   //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
   //m_vecCanvas[trigToDraw].push_back(canvas);
@@ -671,14 +674,14 @@ int JetDraw::DrawJetSeed(const uint32_t trigToDraw, const JetRes resToDraw)
   }
   
   QADrawClient *cl = QADrawClient::instance();
-  TH2F *jetseedcount_rawetavsphi = dynamic_cast<TH2F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawetavsphi")));
-  TH1F *jetseedcount_rawpt = dynamic_cast<TH1F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawpt")));
-  TH1F *jetseedcount_rawptall = dynamic_cast<TH1F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawptall")));
-  TH1F *jetseedcount_rawseedcount = dynamic_cast<TH1F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawseedcount")));
-  TH2F *jetseedcount_subetavsphi = dynamic_cast<TH2F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subetavsphi")));
-  TH1F *jetseedcount_subpt = dynamic_cast<TH1F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subpt")));
-  TH1F *jetseedcount_subptall = dynamic_cast<TH1F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subptall")));  
-  TH1F *jetseedcount_subseedcount = dynamic_cast<TH1F *>(cl->getHisto(histprefix3 + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subseedcount")));
+  TH2F *jetseedcount_rawetavsphi = dynamic_cast<TH2F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawetavsphi")));
+  TH1F *jetseedcount_rawpt = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawpt")));
+  TH1F *jetseedcount_rawptall = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawptall")));
+  TH1F *jetseedcount_rawseedcount = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_rawseedcount")));
+  TH2F *jetseedcount_subetavsphi = dynamic_cast<TH2F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subetavsphi")));
+  TH1F *jetseedcount_subpt = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subpt")));
+  TH1F *jetseedcount_subptall = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subptall")));  
+  TH1F *jetseedcount_subseedcount = dynamic_cast<TH1F *>(cl->getHisto(m_seed_prefix + m_mapTrigToTag[trigToDraw] + m_mapResToTag[resToDraw] + std::string("_subseedcount")));
   
   //TCanvas* canvas = new TCanvas("canvas_name", "Title", 800, 600);
   //m_vecCanvas[trigToDraw].push_back(canvas);

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -17,6 +17,7 @@ class TH1;
 class TH2;
 
 // aliases for convenience
+using VPad1D    = std::vector<TPad*>;
 using VPad2D    = std::vector<std::vector<TPad*>>;
 using VPad3D    = std::vector<std::vector<std::vector<TPad*>>>;
 using VCanvas1D = std::vector<TCanvas*>;
@@ -45,9 +46,7 @@ class JetDraw : public QADraw
  
 
  private:
-  int MakeCanvas(const std::string &name, int num);
-  int nDrawError;
-  int idraw;
+  int MakeCanvas(const std::string &name, const int nHist, TCanvas* canvas, TPad* run, VPad1D& pads);
 
   int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
   int DrawRho(uint32_t trigger);
@@ -70,10 +69,10 @@ class JetDraw : public QADraw
   VCanvas2D m_vecSeedCanvas;
 
   // for adding run numbers to canvases
-  VCanvas1D m_vecRhoRun;
-  VCanvas2D m_vecCstRun;
-  VCanvas2D m_vecKineRun;
-  VCanvas2D m_vecSeedRun;
+  VPad1D m_vecRhoRun;
+  VPad2D m_vecCstRun;
+  VPad2D m_vecKineRun;
+  VPad2D m_vecSeedRun;
 
   // for individual pads on each canvas
   VPad2D m_vecRhoPad;

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -35,14 +35,13 @@ class JetDraw : public QADraw
     R04,
     R05
   };
-    
+
   JetDraw(const std::string &name = "JetQA");
   ~JetDraw() override;
-  int Draw(const std::string &what = "ALL") override;
   int MakeHtml(const std::string &what = "ALL") override;
+  int Draw(const std::string &what = "ALL") override;
   int DBVarInit();
   void SetJetSummary(TCanvas* c);
- 
 
  private:
   int MakeCanvas(const std::string &name, const int nHist, TCanvas* canvas, TPad* run, VPad1D& pads);
@@ -77,15 +76,18 @@ class JetDraw : public QADraw
   const char* m_kinematic_prefix;
   const char* m_seed_prefix;
 
+  // jet type (TODO will need to expand this to a vector in the future)
+  const char* m_jet_type;
+
   // triggers we want to draw
   std::vector<uint32_t> m_vecTrigToDraw = {
-    JetQADefs::GL1::Jet1,
-    JetQADefs::GL1::Jet2,
-    JetQADefs::GL1::Jet3,
-    JetQADefs::GL1::Jet4
+    JetQADefs::GL1::MBDNSJet1,
+    JetQADefs::GL1::MBDNSJet2,
+    JetQADefs::GL1::MBDNSJet3,
+    JetQADefs::GL1::MBDNSJet4
   };
 
-  // vector  we want to draw
+  // resolutions we want to draw
   std::vector<uint32_t> m_vecResToDraw = {
     JetRes::R02,
     JetRes::R03,
@@ -111,19 +113,19 @@ class JetDraw : public QADraw
 
   // map of trigger index onto name
   std::map<uint32_t, std::string> m_mapTrigToName = {
-    {JetQADefs::GL1::Jet1, "Jet6GeV"},
-    {JetQADefs::GL1::Jet2, "Jet8GeV"},
-    {JetQADefs::GL1::Jet3, "Jet10GeV"},
-    {JetQADefs::GL1::Jet4, "Jet12GeV"}
+    {JetQADefs::GL1::MBDNSJet1, "JetCoin6GeV"},
+    {JetQADefs::GL1::MBDNSJet2, "JetCoin8GeV"},
+    {JetQADefs::GL1::MBDNSJet3, "JetCoin10GeV"},
+    {JetQADefs::GL1::MBDNSJet4, "JetCoin12GeV"}
   };
 
   // map trig to tag
   std::map<uint32_t, std::string> m_mapTrigToTag = {
     {JetQADefs::GL1::MBDNS1, "mbdns1"},
-    {JetQADefs::GL1::Jet1, "mbdnsjet1"},
-    {JetQADefs::GL1::Jet2, "mbdnsjet2"},
-    {JetQADefs::GL1::Jet3, "mbdnsjet3"},
-    {JetQADefs::GL1::Jet4, "mbdnsjet4"}
+    {JetQADefs::GL1::MBDNSJet1, "mbdnsjet1"},
+    {JetQADefs::GL1::MBDNSJet2, "mbdnsjet2"},
+    {JetQADefs::GL1::MBDNSJet3, "mbnsjet3"},
+    {JetQADefs::GL1::MBDNSJet4, "mbnsjet4"}
   };
 };
 #endif

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -23,19 +23,18 @@ using VPad3D    = std::vector<std::vector<std::vector<TPad*>>>;
 using VCanvas1D = std::vector<TCanvas*>;
 using VCanvas2D = std::vector<std::vector<TCanvas*>>;
 
-
 class JetDraw : public QADraw
 {
  public:
 
   // tags for jet resolutions
-    enum JetRes
-    {
-      R02,
-      R03,
-      R04,
-      R05
-    };
+  enum JetRes
+  {
+    R02,
+    R03,
+    R04,
+    R05
+  };
     
   JetDraw(const std::string &name = "JetQA");
   ~JetDraw() override;
@@ -47,19 +46,12 @@ class JetDraw : public QADraw
 
  private:
   int MakeCanvas(const std::string &name, const int nHist, TCanvas* canvas, TPad* run, VPad1D& pads);
-
-  int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
   int DrawRho(uint32_t trigger);
+  int DrawConstituents(uint32_t trigToDraw, JetRes resToDraw);
   int DrawJetKinematics(uint32_t trigger, JetRes reso);
   int DrawJetSeed(uint32_t trigger, JetRes reso);
-
   void myText(double x, double y, int color, const char *text, double tsize = 0.04);
-  const static int ncanvases = 8;
-  const static int maxpads = 6;
-  TCanvas *TC[ncanvases]{};
-  TPad *transparent[ncanvases]{};
-  TPad *Pad[ncanvases][maxpads]{};
-//
+
   TCanvas* jetSummary = nullptr;
 
   // canvases for drawing
@@ -92,6 +84,7 @@ class JetDraw : public QADraw
     JetQADefs::GL1::Jet3,
     JetQADefs::GL1::Jet4
   };
+
   // vector  we want to draw
   std::vector<uint32_t> m_vecResToDraw = {
     JetRes::R02,
@@ -115,6 +108,7 @@ class JetDraw : public QADraw
     {JetRes::R04, "r04"},
     {JetRes::R05, "r05"}
   };
+
   // map of trigger index onto name
   std::map<uint32_t, std::string> m_mapTrigToName = {
     {JetQADefs::GL1::Jet1, "Jet6GeV"},

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -46,7 +46,6 @@ class JetDraw : public QADraw
 
  private:
   int MakeCanvas(const std::string &name, int num);
-  QADrawClient* cl; // Declare cl here   
   int nDrawError;
   int idraw;
 

--- a/subsystems/jets/JetDraw.h
+++ b/subsystems/jets/JetDraw.h
@@ -17,6 +17,13 @@ class TH1;
 class TH2;
 //class JetGoodRunChecker; TBD
 
+// aliases for convenience
+using VPad2D    = std::vector<std::vector<TPad*>>;
+using VPad3D    = std::vector<std::vector<std::vector<TPad*>>>;
+using VCanvas1D = std::vector<TCanvas*>;
+using VCanvas2D = std::vector<std::vector<TCanvas*>>;
+
+
 class JetDraw : public QADraw
 {
  public:
@@ -41,7 +48,6 @@ class JetDraw : public QADraw
  private:
   int MakeCanvas(const std::string &name, int num);
   QADrawClient* cl; // Declare cl here   
-  std::vector<std::vector<TCanvas*>> m_vecCanvas;  // Declare m_vecCanvas
   int nDrawError;
   int idraw;
 
@@ -56,12 +62,33 @@ class JetDraw : public QADraw
   //  TH1 *FBratio(TH1 *h);
   void myText(double x, double y, int color, const char *text, double tsize = 0.04);
   //  QADB *db {nullptr};
+// REMOVE
   const static int ncanvases = 8;
   const static int maxpads = 6;
   TCanvas *TC[ncanvases]{};
   TPad *transparent[ncanvases]{};
   TPad *Pad[ncanvases][maxpads]{};
+//
   TCanvas* jetSummary = nullptr;
+
+  // canvases for drawing
+  VCanvas1D m_vecRhoCanvas;
+  VCanvas2D m_vecCstCanvas;
+  VCanvas2D m_vecKineCanvas;
+  VCanvas2D m_vecSeedCanvas;
+
+  // for adding run numbers to canvases
+  VCanvas1D m_vecRhoRun;
+  VCanvas2D m_vecCstRun;
+  VCanvas2D m_vecKineRun;
+  VCanvas2D m_vecSeedRun;
+
+  // for individual pads on each canvas
+  VPad2D m_vecRhoPad;
+  VPad3D m_vecCstPad;
+  VPad3D m_vecKinePad;
+  VPad3D m_vecSeedPad;
+
   // add summary canvases for hcal etc later
   const char *histprefix;
   const char *histprefix1;


### PR DESCRIPTION
This PR updates the logic of how `TCanvas`s and `TPad`s are managed to use `std::vector`s rather than c-style arrays. It also makes a few minor fixes including simplifying histogram name construction, adding missing tags, making return codes consistent across methods, and doing some clean up on white space and ordering of methods.