### PR TITLE
adding output file line to complete the macro function

### DIFF
--- a/subsystems/jets/macros/makehtml.sh
+++ b/subsystems/jets/macros/makehtml.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 [[ -e htmlrunning ]] && exit 0
 echo $$ > htmlrunning
-source ./setup_all.sh
+source /sphenix/user/jamesj3j3/QAhtml/makehtml/setup_all.sh
 Xvfb :2 -nolisten tcp &
 export DISPLAY=unix:2
-for i in /sphenix/data/data02/sphnxpro/QAhtml/aggregated/HIST_JETS_*.root; do
-root.exe -q draw_calo_jet.C\(\"${i}\"\); done
+
+for i in /sphenix/tg/tg01/jets/vbailey/run25_jet_hists/new_newcdbtag_v005/HIST_JETQA-*.root; do
+  outfile="output/output_$(basename "$i")"
+  root.exe -q "draw_calo_jet.C(\"${i}\", \"${outfile}\", false, true)" #very strange - do not run with root.exe -b 
+done
+
 kill $!
 rm htmlrunning


### PR DESCRIPTION
The original function in draw_calo_jet.C requires an input file and an output file. The makehtml.sh did not have an output file set.